### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
 # ProtoLinkAI 🚀 
+
+[![smithery badge](https://smithery.ai/badge/@StevenROyola/ProtoLink)](https://smithery.ai/server/@StevenROyola/ProtoLink)
 
 **ProtoLink AI** is a standardized **tool wrapping framework** for implementing and managing diverse tools in a unified way. It is designed to help developers quickly integrate and launch tool-based use cases.
 
@@ -39,6 +40,14 @@ Here’s why **MCP** matters:
 ---
 
 ## Installation 📦
+
+### Installing via Smithery
+
+To install ProtoLinkAI for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@StevenROyola/ProtoLink):
+
+```bash
+npx -y @smithery/cli install @StevenROyola/ProtoLink --client claude
+```
 
 ### Install via PyPI
 ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,77 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - localTimezone
+      - twitterUsername
+      - twitterPassword
+      - twitterEmail
+      - twitterApiKey
+      - twitterApiSecret
+      - twitterAccessToken
+      - twitterAccessSecret
+      - twitterClientId
+      - twitterClientSecret
+      - twitterBearerToken
+      - elizaPath
+      - elizaApiUrl
+      - personalityConfig
+      - anthropicApiKey
+      - runAgent
+    properties:
+      localTimezone:
+        type: string
+        description: The local timezone for the server.
+      twitterUsername:
+        type: string
+        description: Twitter username for Twitter integration.
+      twitterPassword:
+        type: string
+        description: Twitter password for Twitter integration.
+      twitterEmail:
+        type: string
+        description: Twitter email for Twitter integration.
+      twitterApiKey:
+        type: string
+        description: Twitter API key for Twitter integration.
+      twitterApiSecret:
+        type: string
+        description: Twitter API secret for Twitter integration.
+      twitterAccessToken:
+        type: string
+        description: Twitter access token for Twitter integration.
+      twitterAccessSecret:
+        type: string
+        description: Twitter access secret for Twitter integration.
+      twitterClientId:
+        type: string
+        description: Twitter client ID for Twitter integration.
+      twitterClientSecret:
+        type: string
+        description: Twitter client secret for Twitter integration.
+      twitterBearerToken:
+        type: string
+        description: Twitter bearer token for Twitter integration.
+      elizaPath:
+        type: string
+        description: Path to the Eliza installation.
+      elizaApiUrl:
+        type: string
+        description: API URL for the Eliza integration.
+      personalityConfig:
+        type: string
+        description: Path to the personality config JSON.
+      anthropicApiKey:
+        type: string
+        description: API key for Anthropic integration.
+      runAgent:
+        type: boolean
+        description: Flag to run the agent.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'mcpagentai', args: [], env: {LOCAL_TIMEZONE: config.localTimezone, TWITTER_USERNAME: config.twitterUsername, TWITTER_PASSWORD: config.twitterPassword, TWITTER_EMAIL: config.twitterEmail, TWITTER_API_KEY: config.twitterApiKey, TWITTER_API_SECRET: config.twitterApiSecret, TWITTER_ACCESS_TOKEN: config.twitterAccessToken, TWITTER_ACCESS_SECRET: config.twitterAccessSecret, TWITTER_CLIENT_ID: config.twitterClientId, TWITTER_CLIENT_SECRET: config.twitterClientSecret, TWITTER_BEARER_TOKEN: config.twitterBearerToken, ELIZA_PATH: config.elizaPath, ELIZA_API_URL: config.elizaApiUrl, PERSONALITY_CONFIG: config.personalityConfig, ANTHROPIC_API_KEY: config.anthropicApiKey, RUN_AGENT: config.runAgent ? 'True' : 'False'}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@StevenROyola/ProtoLink?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂